### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Term/ProgressBar.pm
+++ b/lib/Term/ProgressBar.pm
@@ -1,5 +1,5 @@
 use v6;
-class Term::ProgressBar;
+unit class Term::ProgressBar;
 
 has Int $.count = 100;
 has Str $.name = " ";


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.