### PR TITLE
Add `use nqp` pragma

### DIFF
--- a/lib/Term/ProgressBar.pm
+++ b/lib/Term/ProgressBar.pm
@@ -1,4 +1,5 @@
 use v6;
+use nqp;
 class Term::ProgressBar;
 
 has Int $.count = 100;


### PR DESCRIPTION
The use of nqp::operations has been deprecated for non-CORE code.  If one
wishes to use nqp operations within non-CORE code, then the `use nqp` pragma
is required.